### PR TITLE
[Chore] Update rocket dependency, resolve error, update package version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "rocket-slogger"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["iferc <github@iferc.ca>"]
 edition = "2021"
 description = """
-Middleware (fairing) for Rocket.rs 0.5-rc.2 web servers to have integrated slog logging of request activity
+Middleware (fairing) for Rocket.rs 0.5-rc.4 web servers to have integrated slog logging of request activity
 """
 repository = "https://github.com/iferc/rocket-slogger"
 keywords = ["rocket", "slog", "slogger", "logging", "middleware"]
@@ -13,7 +13,7 @@ readme = "./README.md"
 exclude = [".github", "examples"]
 
 [dependencies]
-rocket = "0.5.0-rc.2"
+rocket = "0.5.0-rc.4"
 slog = "2.7"
 slog-term = { version = "2.9", optional = true }
 slog-bunyan = { version = "2.4", optional = true }

--- a/src/from_request.rs
+++ b/src/from_request.rs
@@ -15,7 +15,7 @@ impl<'r> FromRequest<'r> for Slogger {
                 rocket::outcome::Outcome::Success(Slogger::from_logger(logger))
             }
 
-            _ => Outcome::Failure((Status::InternalServerError, ())),
+            _ => Outcome::Error((Status::InternalServerError, ())),
         }
     }
 }


### PR DESCRIPTION
To continue to use this internally with our product, I'm proposing a version upgrade to account for breaking changes in `Outcome` enums.

See https://github.com/SergioBenitez/Rocket/blob/v0.5.0-rc.4/CHANGELOG.md#version-050-rc4-nov-1-2023
And internal branch https://github.com/WeeverApps/wx-data-services/tree/chore-upgrade-rocket-v0.5.0-rc.4